### PR TITLE
#14 model cleanup

### DIFF
--- a/pykeadhcp/models/dhcp6/pd_pool.py
+++ b/pykeadhcp/models/dhcp6/pd_pool.py
@@ -1,9 +1,9 @@
 from typing import Optional, List
-from pykeadhcp.models.generic.base import KeaBaseModel
+from pykeadhcp.models.generic.base import KeaModel
 from pykeadhcp.models.generic.option_data import OptionData
 
 
-class PDPool(KeaBaseModel):
+class PDPool(KeaModel):
     prefix: str
     prefix_len: int
     delegated_len: int
@@ -12,6 +12,3 @@ class PDPool(KeaBaseModel):
     require_client_classes: Optional[List[str]] = []
     excluded_prefix: Optional[str]
     excluded_prefix_len: Optional[int]
-    user_context: Optional[dict]
-    comment: Optional[str]
-    unknown_map_entry: Optional[str]

--- a/pykeadhcp/models/generic/base.py
+++ b/pykeadhcp/models/generic/base.py
@@ -1,3 +1,4 @@
+from typing import Optional
 from pydantic import BaseModel
 
 
@@ -10,3 +11,9 @@ class KeaBaseModel(BaseModel):
         alias_generator = normalize_keys
         allow_population_by_field_name = True
         use_enum_values = True
+
+
+class KeaModel(KeaBaseModel):
+    user_context: Optional[dict]
+    comment: Optional[str]
+    unknown_map_entry: Optional[str]

--- a/pykeadhcp/models/generic/config.py
+++ b/pykeadhcp/models/generic/config.py
@@ -1,16 +1,13 @@
 from typing import Optional, List, Union
-from pykeadhcp.models.generic.base import KeaBaseModel
+from pykeadhcp.models.generic.base import KeaModel
 from pykeadhcp.models.generic.hook import Hook
 from pykeadhcp.models.generic.logger import Logger
 from pykeadhcp.models.generic.option_data import OptionData
 from pykeadhcp.models.enums import ReservationMode, DDNSReplaceClientNameEnum
 
 
-class CommonConfig(KeaBaseModel):
+class CommonConfig(KeaModel):
     store_extended_info: Optional[bool]
-    user_context: Optional[dict]
-    comment: Optional[str]
-    unknown_map_entry: Optional[str]
 
 
 class CommonDhcpConfig(CommonConfig):

--- a/pykeadhcp/models/generic/logger.py
+++ b/pykeadhcp/models/generic/logger.py
@@ -1,6 +1,6 @@
 from typing import Optional, List
 from pydantic import conint
-from pykeadhcp.models.generic.base import KeaBaseModel
+from pykeadhcp.models.generic.base import KeaBaseModel, KeaModel
 from pykeadhcp.models.enums import LoggerLevelEnum
 
 
@@ -12,14 +12,11 @@ class Output(KeaBaseModel):
     pattern: Optional[str]
 
 
-class Logger(KeaBaseModel):
+class Logger(KeaModel):
     name: str
     output_options: Optional[List[Output]] = []
     debuglevel: conint(ge=0, le=100)
     severity: Optional[LoggerLevelEnum]
-    user_context: Optional[dict]
-    comment: Optional[str]
-    unknown_map_entry: Optional[str]
 
     class Config:
         fields = {"output_options": "output_options"}

--- a/pykeadhcp/models/generic/option_data.py
+++ b/pykeadhcp/models/generic/option_data.py
@@ -1,14 +1,11 @@
 from typing import Optional
-from pykeadhcp.models.generic.base import KeaBaseModel
+from pykeadhcp.models.generic.base import KeaModel
 
 
-class OptionData(KeaBaseModel):
+class OptionData(KeaModel):
     data: str
     name: Optional[str]
     code: Optional[int]
     space: Optional[str]
     csv_format: Optional[bool]
     always_send: Optional[bool]
-    user_context: Optional[dict]
-    comment: Optional[str]
-    unknown_map_entry: Optional[str]

--- a/pykeadhcp/models/generic/pool.py
+++ b/pykeadhcp/models/generic/pool.py
@@ -1,13 +1,10 @@
 from typing import Optional, List
-from pykeadhcp.models.generic.base import KeaBaseModel
+from pykeadhcp.models.generic.base import KeaModel
 from pykeadhcp.models.generic.option_data import OptionData
 
 
-class Pool(KeaBaseModel):
+class Pool(KeaModel):
     pool: str
     option_data: Optional[List[OptionData]] = []
     client_class: Optional[str]
     require_client_classes: Optional[str]
-    user_context: Optional[dict]
-    comment: Optional[str]
-    unknown_map_entry: Optional[str]

--- a/pykeadhcp/models/generic/reservation.py
+++ b/pykeadhcp/models/generic/reservation.py
@@ -1,15 +1,12 @@
 from typing import Optional, List
-from pykeadhcp.models.generic.base import KeaBaseModel
+from pykeadhcp.models.generic.base import KeaModel
 from pykeadhcp.models.generic.option_data import OptionData
 
 
-class Reservation(KeaBaseModel):
+class Reservation(KeaModel):
     duid: Optional[str]
     client_classes: Optional[List[str]] = []
     flex_id: Optional[str]
     hw_address: Optional[str]
     hostname: Optional[str]
     option_data: Optional[List[OptionData]] = []
-    user_context: Optional[dict]
-    comment: Optional[str]
-    unknown_map_entry: Optional[str]


### PR DESCRIPTION
Local test

```
(.venv) brandon@dev-1:~/pykeadhcp$ pytest -s tests/ -k "not shutdown and not delta"
============================================================================================ test session starts ============================================================================================
platform linux -- Python 3.10.6, pytest-7.2.2, pluggy-1.0.0
rootdir: /home/brandon/pykeadhcp
collected 174 items / 7 deselected / 167 selected                                                                                                                                                           

tests/ci/models/test_ci_kea_ctrlagent_config_model.py .....
tests/ci/models/test_ci_kea_dhcp4_config_model.py .........
tests/ci/parsers/test_ci_kea_dhcp4_parser.py ...........................
tests/ci/parsers/test_ci_kea_dhcp6_parser.py ..............................
tests/ctrlagent/test_kea_ctrlagent.py ........
tests/ctrlagent/test_kea_ctrlagent_parser.py ..
tests/dhcp4/test_kea_dhcp4.py ...........
tests/dhcp4/test_kea_dhcp4_lease4.py ...........
tests/dhcp4/test_kea_dhcp4_network4.py .......
tests/dhcp4/test_kea_dhcp4_parser.py ..
tests/dhcp4/test_kea_dhcp4_statistics.py ...
tests/dhcp4/test_kea_dhcp4_subnet4.py .........
tests/dhcp6/test_kea_dhcp6.py ...........
tests/dhcp6/test_kea_dhcp6_lease6.py ...........
tests/dhcp6/test_kea_dhcp6_network6.py ........
tests/dhcp6/test_kea_dhcp6_parser.py ..
tests/dhcp6/test_kea_dhcp6_statistics.py ...
tests/dhcp6/test_kea_dhcp6_subnet6.py ........

==================================================================================== 167 passed, 7 deselected in 11.25s =====================================================================================
```