### PR TITLE
Introducing Dhcp6 parsers, model cleanup and ssl/tls support - Prerelease

### DIFF
--- a/pykeadhcp/kea.py
+++ b/pykeadhcp/kea.py
@@ -2,7 +2,7 @@ import requests
 from requests.auth import HTTPBasicAuth
 from requests.exceptions import HTTPError
 from pathlib import Path
-from typing import List
+from typing import List, Union
 
 from pykeadhcp.daemons import CtrlAgent, Ddns, Dhcp4, Dhcp6
 from pykeadhcp.models.generic import KeaResponse
@@ -32,6 +32,8 @@ class Kea:
             (as per self.RESPONSE_CODES). Set this to False if you want to catch the API endpoint specific
             errors such as `v4 Shared Network not found` vs `Code 3: the requested operation has been completed but the requested resource was not found.
             This status code is returned when a command returns no resources or affects no resources.`
+        verify:                 Boolean is used if the server TLS cert is verified or not, however you can
+            pass in a string which should be a path to a CA bundle to use with each request.
     """
 
     def __init__(
@@ -43,6 +45,7 @@ class Kea:
         username: str = "",
         password: str = "",
         raise_generic_errors: bool = False,
+        verify: Union[bool, str] = True,
     ):
         self.host = host
         self.port = port
@@ -52,6 +55,7 @@ class Kea:
         self.services = ["dhcp4", "dhcp6", "ddns", None]  # None = Control-Agent Daemon
         self.url = f"{self.host}:{self.port}"
         self.raise_generic_errors = raise_generic_errors
+        self.verify = verify
         self.RESPONSE_CODES = {
             1: KeaGenericException,
             2: KeaCommandNotSupportedException,
@@ -122,6 +126,7 @@ class Kea:
             json=body,
             headers=self.headers,
             auth=self.basic_auth if self.use_basic_auth else None,
+            verify=self.verify,
             **kwargs,
         )
 

--- a/pykeadhcp/models/dhcp6/pd_pool.py
+++ b/pykeadhcp/models/dhcp6/pd_pool.py
@@ -1,9 +1,9 @@
 from typing import Optional, List
-from pykeadhcp.models.generic.base import KeaBaseModel
+from pykeadhcp.models.generic.base import KeaModel
 from pykeadhcp.models.generic.option_data import OptionData
 
 
-class PDPool(KeaBaseModel):
+class PDPool(KeaModel):
     prefix: str
     prefix_len: int
     delegated_len: int
@@ -12,6 +12,3 @@ class PDPool(KeaBaseModel):
     require_client_classes: Optional[List[str]] = []
     excluded_prefix: Optional[str]
     excluded_prefix_len: Optional[int]
-    user_context: Optional[dict]
-    comment: Optional[str]
-    unknown_map_entry: Optional[str]

--- a/pykeadhcp/models/generic/base.py
+++ b/pykeadhcp/models/generic/base.py
@@ -1,3 +1,4 @@
+from typing import Optional
 from pydantic import BaseModel
 
 
@@ -10,3 +11,9 @@ class KeaBaseModel(BaseModel):
         alias_generator = normalize_keys
         allow_population_by_field_name = True
         use_enum_values = True
+
+
+class KeaModel(KeaBaseModel):
+    user_context: Optional[dict]
+    comment: Optional[str]
+    unknown_map_entry: Optional[str]

--- a/pykeadhcp/models/generic/config.py
+++ b/pykeadhcp/models/generic/config.py
@@ -1,16 +1,13 @@
 from typing import Optional, List, Union
-from pykeadhcp.models.generic.base import KeaBaseModel
+from pykeadhcp.models.generic.base import KeaModel
 from pykeadhcp.models.generic.hook import Hook
 from pykeadhcp.models.generic.logger import Logger
 from pykeadhcp.models.generic.option_data import OptionData
 from pykeadhcp.models.enums import ReservationMode, DDNSReplaceClientNameEnum
 
 
-class CommonConfig(KeaBaseModel):
+class CommonConfig(KeaModel):
     store_extended_info: Optional[bool]
-    user_context: Optional[dict]
-    comment: Optional[str]
-    unknown_map_entry: Optional[str]
 
 
 class CommonDhcpConfig(CommonConfig):

--- a/pykeadhcp/models/generic/logger.py
+++ b/pykeadhcp/models/generic/logger.py
@@ -1,6 +1,6 @@
 from typing import Optional, List
 from pydantic import conint
-from pykeadhcp.models.generic.base import KeaBaseModel
+from pykeadhcp.models.generic.base import KeaBaseModel, KeaModel
 from pykeadhcp.models.enums import LoggerLevelEnum
 
 
@@ -12,14 +12,11 @@ class Output(KeaBaseModel):
     pattern: Optional[str]
 
 
-class Logger(KeaBaseModel):
+class Logger(KeaModel):
     name: str
     output_options: Optional[List[Output]] = []
     debuglevel: conint(ge=0, le=100)
     severity: Optional[LoggerLevelEnum]
-    user_context: Optional[dict]
-    comment: Optional[str]
-    unknown_map_entry: Optional[str]
 
     class Config:
         fields = {"output_options": "output_options"}

--- a/pykeadhcp/models/generic/option_data.py
+++ b/pykeadhcp/models/generic/option_data.py
@@ -1,14 +1,11 @@
 from typing import Optional
-from pykeadhcp.models.generic.base import KeaBaseModel
+from pykeadhcp.models.generic.base import KeaModel
 
 
-class OptionData(KeaBaseModel):
+class OptionData(KeaModel):
     data: str
     name: Optional[str]
     code: Optional[int]
     space: Optional[str]
     csv_format: Optional[bool]
     always_send: Optional[bool]
-    user_context: Optional[dict]
-    comment: Optional[str]
-    unknown_map_entry: Optional[str]

--- a/pykeadhcp/models/generic/pool.py
+++ b/pykeadhcp/models/generic/pool.py
@@ -1,13 +1,10 @@
 from typing import Optional, List
-from pykeadhcp.models.generic.base import KeaBaseModel
+from pykeadhcp.models.generic.base import KeaModel
 from pykeadhcp.models.generic.option_data import OptionData
 
 
-class Pool(KeaBaseModel):
+class Pool(KeaModel):
     pool: str
     option_data: Optional[List[OptionData]] = []
     client_class: Optional[str]
     require_client_classes: Optional[str]
-    user_context: Optional[dict]
-    comment: Optional[str]
-    unknown_map_entry: Optional[str]

--- a/pykeadhcp/models/generic/reservation.py
+++ b/pykeadhcp/models/generic/reservation.py
@@ -1,15 +1,12 @@
 from typing import Optional, List
-from pykeadhcp.models.generic.base import KeaBaseModel
+from pykeadhcp.models.generic.base import KeaModel
 from pykeadhcp.models.generic.option_data import OptionData
 
 
-class Reservation(KeaBaseModel):
+class Reservation(KeaModel):
     duid: Optional[str]
     client_classes: Optional[List[str]] = []
     flex_id: Optional[str]
     hw_address: Optional[str]
     hostname: Optional[str]
     option_data: Optional[List[OptionData]] = []
-    user_context: Optional[dict]
-    comment: Optional[str]
-    unknown_map_entry: Optional[str]

--- a/pykeadhcp/parsers/dhcp6.py
+++ b/pykeadhcp/parsers/dhcp6.py
@@ -1,6 +1,15 @@
 from pykeadhcp.parsers.generic import GenericParser
 from pykeadhcp.models.dhcp6.config import Dhcp6DaemonConfig
+from pykeadhcp.models.dhcp6.shared_network import SharedNetwork6
 from pykeadhcp.models.dhcp6.subnet import Subnet6
+from pykeadhcp.models.dhcp6.reservation import Reservation6
+from pykeadhcp.models.generic.pool import Pool
+from pykeadhcp.models.dhcp6.pd_pool import PDPool
+from pykeadhcp.models.generic.option_data import OptionData
+from pykeadhcp.models.enums import HostReservationIdentifierEnum
+from pykeadhcp.parsers import exceptions
+
+from ipaddress import IPv6Address, IPv6Network
 
 
 class Dhcp6Parser(GenericParser):
@@ -12,3 +21,504 @@ class Dhcp6Parser(GenericParser):
 
     def __init__(self, config: dict):
         self.config = Dhcp6DaemonConfig.parse_obj(config["Dhcp6"])
+
+    def get_shared_network(self, name: str) -> SharedNetwork6:
+        """Returns a specific Dhcp6 shared-network
+
+        Args:
+            name:       Name of the shared-network
+        """
+        for shared_network in self.config.shared_networks:
+            if shared_network.name == name:
+                return shared_network
+
+    def get_subnet(self, id: int) -> Subnet6:
+        """Attempts to return the first found subnet based on the subnets id using
+        global subnets first then shared-networks last.
+
+        Args:
+            id:     ID of the subnet
+        """
+        for subnet in self.config.subnet6:
+            if subnet.id == id:
+                return subnet
+
+        for shared_network in self.config.shared_networks:
+            for subnet in shared_network.subnet6:
+                if subnet.id == id:
+                    return subnet
+
+    def get_subnet_by_cidr(self, cidr: str) -> Subnet6:
+        """Attempts to return the first found subnet based on the provided cidr
+        using global subnets first and then shared-networks last.
+
+        Args:
+            cidr:       IPv6 CIDR (eg. 2001:db8::/64)
+        """
+        for subnet in self.config.subnet6:
+            if subnet.subnet == cidr:
+                return subnet
+
+        for shared_network in self.config.shared_networks:
+            for subnet in shared_network.subnet6:
+                if subnet.subnet == cidr:
+                    return subnet
+
+    def add_shared_network(self, name: str, **kwargs) -> SharedNetwork6:
+        """Attempts to add a shared network if it doesn't already
+        exist
+
+        Args:
+            name:       Name of the shared network
+        """
+        if self.get_shared_network(name):
+            raise exceptions.ParserSharedNetworkAlreadyExistError(name)
+        network = SharedNetwork6(name=name, **kwargs)
+        self.config.shared_networks.append(network)
+        return network
+
+    def add_subnet(self, id: int, subnet: str, **kwargs) -> Subnet6:
+        """Attempts to add a Subnet if it doesn't already exist
+
+        Args:
+            id:         Subnet Id
+            subnet:     Subnet (CIDR eg. 2001:db8::/64)
+        """
+        if self.get_subnet(id):
+            raise exceptions.ParserSubnetIDAlreadyExistError(id)
+
+        if self.get_subnet_by_cidr(subnet):
+            raise exceptions.ParserSubnetCIDRAlreadyExistError(subnet)
+
+        subnet = Subnet6(id=id, subnet=subnet, **kwargs)
+        self.config.subnet6.append(subnet)
+        return subnet
+
+    def add_subnet_to_shared_network(self, id: int, name: str) -> Subnet6:
+        """Attempts to assosicate an existing subnet to a shared-network and returns
+        the shared-network
+
+        Args:
+            id:     Subnet ID
+            name:   Name of the shared network
+        """
+        existing_network = self.get_shared_network(name)
+        if not existing_network:
+            raise exceptions.ParserSharedNetworkNotFoundError(name)
+
+        existing_subnet = self.get_subnet(id)
+        if not existing_subnet:
+            raise exceptions.ParserSubnetNotFoundError(id)
+
+        for index, subnet in enumerate(self.config.subnet6):
+            if existing_subnet.id != subnet.id:
+                continue
+
+            subnet_to_assosicate = self.config.subnet6.pop(index)
+            existing_network.subnet6.append(subnet_to_assosicate)
+            return subnet_to_assosicate
+
+    def add_reservation_to_subnet(
+        self, id: int, ip_address: str, **kwargs
+    ) -> Reservation6:
+        """Attempts to add a reservation to an existing subnet
+
+        Args:
+            id:             Subnet ID
+            ip_address:     IP Address of Reservation
+        """
+        if self.get_reservation_by_ip(ip_address):
+            raise exceptions.ParserReservationAlreadyExistError(ip_address)
+
+        existing_subnet = self.get_subnet(id)
+        if not existing_subnet:
+            raise exceptions.ParserSubnetNotFoundError(id)
+
+        reservation = Reservation6(ip_addresses=[ip_address], **kwargs)
+        existing_subnet.reservations.append(reservation)
+        return reservation
+
+    def add_dhcp_option_to_subnet(
+        self, id: int, code: int, data: str, **kwargs
+    ) -> Subnet6:
+        """Attempts to add a DHCP Option to an existing subnet
+
+        Args:
+            id:         Subnet ID
+            code:       DHCP Option Code
+            data:       DHCP Option Data
+        """
+        existing_subnet = self.get_subnet(id)
+        if not existing_subnet:
+            raise exceptions.ParserSubnetNotFoundError
+
+        for existing_option in existing_subnet.option_data:
+            if existing_option.code == code:
+                raise exceptions.ParserOptionDataAlreadyExistError(
+                    f"Subnet (ID: {id})", code
+                )
+
+        option_data = OptionData(code=code, data=data, **kwargs)
+        existing_subnet.option_data.append(option_data)
+        return existing_subnet
+
+    def add_dhcp_option_to_shared_network(
+        self, name: str, code: int, data: str, **kwargs
+    ) -> SharedNetwork6:
+        """Attempts to add a DHCP Option to an existing shared network
+
+        Args:
+            name:       Name of shared network
+            code:       DHCP Option Code
+            data:       DHCP Option Data
+        """
+        existing_shared_network = self.get_shared_network(name)
+        if not existing_shared_network:
+            raise exceptions.ParserSharedNetworkNotFoundError
+
+        for existing_option in existing_shared_network.option_data:
+            if existing_option.code == code:
+                raise exceptions.ParserOptionDataAlreadyExistError(
+                    f"Shared Network ({name})", code
+                )
+
+        option_data = OptionData(code=code, data=data, **kwargs)
+        existing_shared_network.option_data.append(option_data)
+        return existing_shared_network
+
+    def add_pool_to_subnet(self, id: int, start: str, end: str, **kwargs) -> Subnet6:
+        """Attempts to add a pool to an existing subnet
+
+        Args:
+            id:     Subnet ID
+            start:  Pool Start
+            end:    Pool End
+        """
+        try:
+            ipv6_start = IPv6Address(start)
+            ipv6_end = IPv6Address(end)
+        except:
+            raise exceptions.ParserPoolInvalidAddressError(start, end)
+
+        existing_subnet = self.get_subnet(id)
+        if not existing_subnet:
+            raise exceptions.ParserSubnetNotFoundError(id)
+
+        subnet = IPv6Network(existing_subnet.subnet)
+        if ipv6_start not in subnet:
+            raise exceptions.ParserPoolAddressNotInSubnetError(start, subnet)
+
+        if ipv6_end not in subnet:
+            raise exceptions.ParserPoolAddressNotInSubnetError(end, subnet)
+
+        pool_str = f"{start}-{end}"
+        for existing_pool in existing_subnet.pools:
+            if existing_pool.pool == pool_str:
+                raise exceptions.ParserSubnetPoolAlreadyExistError(id, pool_str)
+
+        pool = Pool(pool=pool_str, **kwargs)
+        existing_subnet.pools.append(pool)
+        return existing_subnet
+
+    def get_shared_network_by_subnet(self, subnet: str) -> SharedNetwork6:
+        """Attempts to return the first found Shared Network based on subnet CIDR
+
+        Args:
+            subnet:     Subnet CIDR (eg. 2001:db8::/64)
+        """
+        for shared_network in self.config.shared_networks:
+            for existing_subnet in shared_network.subnet6:
+                if existing_subnet.subnet == subnet:
+                    return shared_network
+
+    def get_shared_network_by_reservation(self, ip_address: str) -> SharedNetwork6:
+        """Attempts to return the first found Shared Network based on a reservations
+        IP address
+
+        Args:
+            ip_address:     IPv6 address of the reservation
+        """
+        for shared_network in self.config.shared_networks:
+            for subnet in shared_network.subnet6:
+                for reservation in subnet.reservations:
+                    for ip in reservation.ip_addresses:
+                        if ip == ip_address:
+                            return shared_network
+
+    def get_subnet_by_reservation(self, ip_address: str) -> Subnet6:
+        """Attempts to return the first subnet found based on a reservations IP address
+        starting with global subnets first and then shared networks
+
+        Args:
+            ip_address:     IPv6 address of the reservation
+        """
+        for subnet in self.config.subnet6:
+            for reservation in subnet.reservations:
+                for ip in reservation.ip_addresses:
+                    if ip == ip_address:
+                        return subnet
+
+        for shared_network in self.config.shared_networks:
+            for subnet in shared_network.subnet6:
+                for reservation in subnet.reservations:
+                    for ip in reservation.ip_addresses:
+                        if ip == ip_address:
+                            return subnet
+
+    def get_subnet_by_default_gateway(self, ip_address: str) -> Subnet6:
+        """Attempts to return the first subnet found based on the default gateway (option 3)
+        starting with global subnets first and then shared networks
+
+        Args:
+            ip_address:     IP address of default gateway
+        """
+        for subnet in self.config.subnet6:
+            for option_data in subnet.option_data:
+                if option_data.code == 3 and option_data.data == ip_address:
+                    return subnet
+
+        for shared_network in self.config.shared_networks:
+            for subnet in shared_network.subnet6:
+                for option_data in subnet.option_data:
+                    if option_data.code == 3 and option_data.data == ip_address:
+                        return subnet
+
+    def get_subnet_by_pool(self, pool: str) -> Subnet6:
+        """Attempts to return the first subnet found based on the pool starting with
+        global subnets first and then shared networks
+
+        Args:
+            pool:       Pool eg. 2001:db8::1-2001:db8::FFFF
+        """
+        for subnet in self.config.subnet6:
+            for existing_pool in subnet.pools:
+                if existing_pool.pool == pool:
+                    return subnet
+
+        for shared_network in self.config.shared_networks:
+            for subnet in shared_network.subnet6:
+                for existing_pool in subnet.pools:
+                    if existing_pool.pool == pool:
+                        return subnet
+
+    def get_reservation_by(
+        self, identifier_type: HostReservationIdentifierEnum, identifier_data: str
+    ) -> Reservation6:
+        """Attempts to return the first found reservation based on the provided
+        identifier_type to look for (eg. ip_address, hw_address, flex_id, etc...)
+
+        Args:
+            identifier_type:    HostReservationIdentifierEnum
+            identifier_data:    Data to match identifier type
+        """
+        identifier_type = identifier_type.value.replace("-", "_")
+        if not Reservation6.__fields__.get(
+            identifier_type
+        ):  # Is this the best way to check fields in Pydantic??
+            raise exceptions.ParserInvalidHostReservationIdentifierError(
+                identifier_type
+            )
+
+        for subnet in self.config.subnet6:
+            for reservation in subnet.reservations:
+                if getattr(reservation, identifier_type) == identifier_data:
+                    return reservation
+
+        for network in self.config.shared_networks:
+            for subnet in network.subnet6:
+                for reservation in subnet.reservations:
+                    if getattr(reservation, identifier_type) == identifier_data:
+                        return reservation
+
+    def get_reservation_by_ip(self, ip_address: str) -> Reservation6:
+        """Attempts to return the first found reservation based on the provided
+        IP address reservation by first looking at the global subnets, then
+        the shared networks
+
+        Args:
+            ip_address:     IP Address of Reservation
+        """
+        for subnet in self.config.subnet6:
+            for reservation in subnet.reservations:
+                for ip in reservation.ip_addresses:
+                    if ip == ip_address:
+                        return reservation
+
+        for network in self.config.shared_networks:
+            for subnet in network.subnet6:
+                for reservation in subnet.reservations:
+                    for ip in reservation.ip_addresses:
+                        if ip == ip_address:
+                            return reservation
+
+    def get_reservation_by_hw_address(self, hw_address: str) -> Reservation6:
+        """Attempts to return the first found reservation based on hw_address
+
+        Args:
+            hw_address:     MAC Address
+        """
+        return self.get_reservation_by(
+            HostReservationIdentifierEnum.hw_address, hw_address
+        )
+
+    def get_reservation_by_flex_id(self, flex_id: str) -> Reservation6:
+        """Attempts to return the first found reservation based on flex_id
+
+        Args:
+            flex_id:        Flex ID
+        """
+        return self.get_reservation_by(HostReservationIdentifierEnum.flex_id, flex_id)
+
+    def get_reservation_by_duid(self, duid: str) -> Reservation6:
+        """Attempts to return the first found reservation based on duid
+
+        Args:
+            duid:   DHCP Unique Identifier
+        """
+        return self.get_reservation_by(HostReservationIdentifierEnum.duid, duid)
+
+    def remove_reservation(self, id: int, ip_address: str) -> Reservation6:
+        """Attempts to remove a reservation from a given subnet and returns
+        the reservation
+
+        Args:
+            id:             Subnet ID
+            ip_address:     IPv6 address of the subnet
+        """
+        existing_subnet = self.get_subnet(id)
+        if not existing_subnet:
+            raise exceptions.ParserSubnetNotFoundError(id)
+
+        for index, existing_reservation in enumerate(existing_subnet.reservations):
+            for ip in existing_reservation.ip_addresses:
+                if ip == ip_address:
+                    reservation = existing_subnet.reservations.pop(index)
+                    return reservation
+
+    def remove_subnet_pool(self, id: int, pool: str) -> Pool:
+        """Attempts to remove a pool from a given subnet and returns
+        the reservation
+
+        Args:
+            id:     Subnet ID
+            pool:   Pool
+        """
+        existing_subnet = self.get_subnet(id)
+        if not existing_subnet:
+            raise exceptions.ParserSubnetNotFoundError(id)
+
+        for index, existing_pool in enumerate(existing_subnet.pools):
+            if existing_pool.pool == pool:
+                pool = existing_subnet.pools.pop(index)
+                return pool
+
+    def remove_subnet_from_shared_network(self, id: int, name: str) -> Subnet6:
+        """Attempts to remove a subnet from a given shared network and
+        returns the subnet
+
+        Args:
+            id:     Subnet ID
+            name:   Name of the shared network
+        """
+        existing_shared_network = self.get_shared_network(name)
+        if not existing_shared_network:
+            raise exceptions.ParserSharedNetworkNotFoundError(name)
+
+        for index, existing_subnet in enumerate(existing_shared_network.subnet6):
+            if existing_subnet.id == id:
+                subnet = existing_shared_network.subnet6.pop(index)
+                return subnet
+
+    def remove_subnet(self, id: int) -> Subnet6:
+        """Attempts to remove a subnet from the global subnets and returns
+        the subnet
+
+        Args:
+            id: Subnet ID
+        """
+        for index, existing_subnet in enumerate(self.config.subnet6):
+            if existing_subnet.id == id:
+                subnet = self.config.subnet6.pop(index)
+                return subnet
+
+    def remove_shared_network(
+        self, name: str, keep_subnets: bool = False
+    ) -> SharedNetwork6:
+        """Attempts to remove a shared network and returns the
+        shared network, if any subnets are found in here, it will also delete them
+        unless you specify keep_subnets as True
+
+        Args:
+            name:           Name of the shared network
+            keep_subnets:   Moves any subnets into the global subnet configuration if True
+        """
+        for index, existing_shared_network in enumerate(self.config.shared_networks):
+            if existing_shared_network.name == name:
+                if keep_subnets:
+                    for subnet in existing_shared_network.subnet6:
+                        self.config.subnet6.append(subnet)
+
+                shared_network = self.config.shared_networks.pop(index)
+                return shared_network
+
+    def get_subnet_from_pd_pool(self, prefix: str, prefix_len: int) -> Subnet6:
+        """Attempts to return the first found subnet that has a PD Pool with
+        matching prefix/len/delegated-len, searches in global subnets first
+        and then shared networks"""
+        for subnet in self.config.subnet6:
+            for pd_pool in subnet.pd_pools:
+                if pd_pool.prefix == prefix and pd_pool.prefix_len == prefix_len:
+                    return subnet
+
+        for shared_network in self.config.shared_networks:
+            for subnet in shared_network.subnet6:
+                for pd_pool in subnet.pd_pools:
+                    if pd_pool.prefix == prefix and pd_pool.prefix_len == prefix_len:
+                        return subnet
+
+    def add_pd_pool(
+        self, id: int, prefix: str, prefix_len: int, delegated_len: int, **kwargs
+    ) -> PDPool:
+        """Attempts to add a PD Pool to an existing subnet
+
+        Args:
+            id:             Subnet ID
+            prefix:         IPv6 PD Prefix
+            prefix_len:     IPv6 PD Prefix Length
+            delegated_len:  IPv6 PD Pool Length (for client)
+        """
+        existing_subnet = self.get_subnet(id)
+        if not existing_subnet:
+            raise exceptions.ParserSubnetNotFoundError(id)
+
+        existing_subnet_with_pd_pool = self.get_subnet_from_pd_pool(prefix, prefix_len)
+        if existing_subnet_with_pd_pool:
+            raise exceptions.ParserPDPoolAlreadyExistError(
+                prefix, prefix_len, existing_subnet_with_pd_pool.id
+            )
+
+        pool = PDPool(
+            prefix=prefix, prefix_len=prefix_len, delegated_len=delegated_len, **kwargs
+        )
+        existing_subnet.pd_pools.append(pool)
+        return pool
+
+    def remove_pd_pool(self, id: int, prefix: str, prefix_len: int) -> PDPool:
+        """Attempts to remove a PD Pool from a given subnet
+
+        Args:
+            id:         Subnet ID
+            prefix:     IPv6 PD Prefix
+            prefix_len: IPv6 PD Prefix Length
+        """
+        existing_subnet_from_pd_pool = self.get_subnet_from_pd_pool(prefix, prefix_len)
+        if not existing_subnet_from_pd_pool:
+            raise exceptions.ParserPDPoolNotFoundError(id, prefix, prefix_len)
+
+        for index, existing_pd_pool in enumerate(existing_subnet_from_pd_pool.pd_pools):
+            if (
+                existing_pd_pool.prefix == prefix
+                and existing_pd_pool.prefix_len == prefix_len
+            ):
+                pd_pool = existing_subnet_from_pd_pool.pd_pools.pop(index)
+                return pd_pool

--- a/pykeadhcp/parsers/exceptions.py
+++ b/pykeadhcp/parsers/exceptions.py
@@ -80,3 +80,17 @@ class ParserInvalidHostReservationIdentifierError(GenericParserError):
     def __init__(self, identifier_type: str):
         self.message = f"Identifier Typer {identifier_type} is not a valid type"
         super().__init__(self.message)
+
+
+class ParserPDPoolAlreadyExistError(GenericParserError):
+    def __init__(self, prefix: str, prefix_len: int, id: int):
+        self.message = (
+            f"PD Prefix {prefix}/{prefix_len} already exist in a subnet ({id})"
+        )
+        super().__init__(self.message)
+
+
+class ParserPDPoolNotFoundError(GenericParserError):
+    def __init__(self, id: int, prefix: str, prefix_len: int):
+        self.message = f"Unable to find PD Prefix {prefix}/{prefix_len} in subnet {id}"
+        super().__init__(self.message)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "pykeadhcp"
-version = "0.3.0"
+version = "0.4.0a0"
 description = "Wrapper around requests module to query ISC Kea DHCP API Daemons (ctrlagent, dhcp4, dhcp6, ddns)"
 authors = ["Brandon Spendlove <brandon-spendlove@hotmail.co.uk>"]
 license = "Apache 2.0"

--- a/tests/ci/parsers/test_ci_kea_dhcp6_parser.py
+++ b/tests/ci/parsers/test_ci_kea_dhcp6_parser.py
@@ -1,0 +1,225 @@
+import pytest
+from pykeadhcp.parsers.dhcp6 import Dhcp6Parser
+from pykeadhcp.parsers.exceptions import (
+    ParserSharedNetworkAlreadyExistError,
+    ParserSubnetIDAlreadyExistError,
+    ParserSubnetCIDRAlreadyExistError,
+    ParserPDPoolAlreadyExistError,
+    ParserPDPoolNotFoundError,
+    ParserReservationAlreadyExistError,
+    ParserSubnetPoolAlreadyExistError,
+    ParserPoolAddressNotInSubnetError,
+)
+
+
+def test_kea_dhcp6_parser_load(dhcp6_parser: Dhcp6Parser):
+    assert dhcp6_parser
+
+
+def test_kea_dhcp6_parser_add_shared_network(dhcp6_parser: Dhcp6Parser):
+    dhcp6_parser.add_shared_network(name="pykeadhcp-dhcp6-parser")
+    assert len(dhcp6_parser.config.shared_networks) > 0
+
+
+def test_kea_dhcp6_parser_add_shared_network_existing(dhcp6_parser: Dhcp6Parser):
+    with pytest.raises(ParserSharedNetworkAlreadyExistError):
+        dhcp6_parser.add_shared_network(name="pykeadhcp-dhcp6-parser")
+
+
+def test_kea_dhcp6_parser_get_shared_network(dhcp6_parser: Dhcp6Parser):
+    shared_network = dhcp6_parser.get_shared_network(name="pykeadhcp-dhcp6-parser")
+    assert shared_network
+
+
+def test_kea_dhcp6_parser_add_shared_network_option(dhcp6_parser: Dhcp6Parser):
+    shared_network = dhcp6_parser.add_dhcp_option_to_shared_network(
+        name="pykeadhcp-dhcp6-parser", code=15, data="pykeadhcp.local"
+    )
+    assert len(shared_network.option_data) > 0
+
+
+def test_kea_dhcp6_parser_add_subnet(dhcp6_parser: Dhcp6Parser):
+    dhcp6_parser.add_subnet(
+        id=40123,
+        subnet="2001:db8::/64",
+        option_data=[{"code": 3, "data": "2001:db8::1"}],
+    )
+    assert len(dhcp6_parser.config.subnet6) > 0
+
+
+def test_kea_dhcp6_parser_add_existing_subnet_id(dhcp6_parser: Dhcp6Parser):
+    with pytest.raises(ParserSubnetIDAlreadyExistError):
+        dhcp6_parser.add_subnet(id=40123, subnet="2001:db8::/64")
+
+
+def test_kea_dhcp6_parser_add_existing_subnet_cidr(dhcp6_parser: Dhcp6Parser):
+    with pytest.raises(ParserSubnetCIDRAlreadyExistError):
+        dhcp6_parser.add_subnet(id=40124, subnet="2001:db8::/64")
+
+
+def test_kea_dhcp6_parser_add_pd_pool(dhcp6_parser: Dhcp6Parser):
+    dhcp6_parser.add_pd_pool(
+        id=40123, prefix="2001:db8::", prefix_len=52, delegated_len=56
+    )
+    existing_subnet = dhcp6_parser.get_subnet(id=40123)
+    assert len(existing_subnet.pd_pools) > 0
+
+
+def test_kea_dhcp6_parser_add_pd_pool_existing(dhcp6_parser: Dhcp6Parser):
+    with pytest.raises(ParserPDPoolAlreadyExistError):
+        existing_subnet = dhcp6_parser.get_subnet(id=40123)
+        assert len(existing_subnet.pd_pools) > 0
+        for pd_pool in existing_subnet.pd_pools:
+            dhcp6_parser.add_pd_pool(
+                id=existing_subnet.id,
+                prefix=pd_pool.prefix,
+                prefix_len=pd_pool.prefix_len,
+                delegated_len=pd_pool.delegated_len,
+            )
+            break
+
+
+def test_kea_dhcp6_parser_remove_pd_pool(dhcp6_parser: Dhcp6Parser):
+    pd_pool = dhcp6_parser.remove_pd_pool(id=40123, prefix="2001:db8::", prefix_len=52)
+    assert pd_pool
+    existing_subnet = dhcp6_parser.get_subnet(id=40123)
+    assert len(existing_subnet.pd_pools) == 0
+
+
+def test_kea_dhcp6_parser_remove_pd_pool_not_exist(dhcp6_parser: Dhcp6Parser):
+    with pytest.raises(ParserPDPoolNotFoundError):
+        dhcp6_parser.remove_pd_pool(id=40123, prefix="2001:db8::", prefix_len=52)
+
+
+def test_kea_dhcp6_parser_add_subnet_reservation(dhcp6_parser: Dhcp6Parser):
+    dhcp6_parser.add_reservation_to_subnet(
+        id=40123,
+        ip_address="2001:db8::123",
+        hw_address="aa:bb:cc:dd:ee:ff",
+        client_id="pykeadhcp-client-id",
+        circuit_id="pykeadhcp-circuit-id",
+        flex_id="pykeadhcp-flex-id",
+        duid="pykeadhcp-duid",
+    )
+
+    subnet = dhcp6_parser.get_subnet(id=40123)
+    assert len(subnet.reservations) > 0
+
+
+def test_kea_dhcp6_parser_add_subnet_reservation_existing(dhcp6_parser: Dhcp6Parser):
+    with pytest.raises(ParserReservationAlreadyExistError):
+        dhcp6_parser.add_reservation_to_subnet(id=40123, ip_address="2001:db8::123")
+
+
+def test_kea_dhcp6_parser_get_reservation_ip(dhcp6_parser: Dhcp6Parser):
+    reservation = dhcp6_parser.get_reservation_by_ip(ip_address="2001:db8::123")
+    assert reservation
+    assert len(reservation.ip_addresses) > 0
+    assert "2001:db8::123" in reservation.ip_addresses
+
+
+def test_kea_dhcp6_parser_get_reservation_not_exist(dhcp6_parser: Dhcp6Parser):
+    no_reservation = dhcp6_parser.get_reservation_by_ip(ip_address="2001:db8::124")
+    assert no_reservation == None
+
+
+def test_kea_dhcp6_parser_get_resrvation_by_hw_address(dhcp6_parser: Dhcp6Parser):
+    reservation = dhcp6_parser.get_reservation_by_hw_address(
+        hw_address="aa:bb:cc:dd:ee:ff"
+    )
+    assert reservation
+    assert "2001:db8::123" in reservation.ip_addresses
+
+
+def test_kea_dhcp6_parser_get_reservation_by_flex_id(dhcp6_parser: Dhcp6Parser):
+    reservation = dhcp6_parser.get_reservation_by_flex_id(flex_id="pykeadhcp-flex-id")
+    assert reservation
+    assert "2001:db8::123" in reservation.ip_addresses
+
+
+def test_kea_dhcp6_parser_change_reservation(dhcp6_parser: Dhcp6Parser):
+    reservation = dhcp6_parser.get_reservation_by_ip(ip_address="2001:db8::123")
+    reservation.duid = "new-duid-id"
+    reservation.flex_id = "new-flex-id"
+
+    assert dhcp6_parser.get_reservation_by_duid(duid="new-duid-id")
+    assert dhcp6_parser.get_reservation_by_flex_id(flex_id="new-flex-id")
+
+
+def test_kea_dhcp6_parser_get_subnet_by_reservation(dhcp6_parser: Dhcp6Parser):
+    subnet = dhcp6_parser.get_subnet_by_reservation(ip_address="2001:db8::123")
+    assert subnet.id == 40123
+
+
+def test_kea_dhcp6_parser_remove_reservation(dhcp6_parser: Dhcp6Parser):
+    dhcp6_parser.remove_reservation(id=40123, ip_address="2001:db8::123")
+
+    no_reservation = dhcp6_parser.get_reservation_by_ip(ip_address="2001:db8::123")
+    assert no_reservation == None
+
+    subnet = dhcp6_parser.get_subnet(id=40123)
+    assert len(subnet.reservations) == 0
+
+
+def test_kea_dhcp6_parser_remove_reservation_not_exist(dhcp6_parser: Dhcp6Parser):
+    no_reservation = dhcp6_parser.remove_reservation(
+        id=40123, ip_address="2001:db8::123"
+    )
+    assert no_reservation == None
+
+
+def test_kea_dhcp6_parser_subnet_add_pool(dhcp6_parser: Dhcp6Parser):
+    subnet = dhcp6_parser.add_pool_to_subnet(
+        id=40123, start="2001:db8::100", end="2001:db8::200"
+    )
+    assert len(subnet.pools) > 0
+
+
+def test_kea_dhcp6_parser_subnet_add_pool_existing(dhcp6_parser: Dhcp6Parser):
+    with pytest.raises(ParserSubnetPoolAlreadyExistError):
+        dhcp6_parser.add_pool_to_subnet(
+            id=40123, start="2001:db8::100", end="2001:db8::200"
+        )
+
+
+def test_kea_dhcp6_parser_subnet_add_pool_bad_ip(dhcp6_parser: Dhcp6Parser):
+    with pytest.raises(ParserPoolAddressNotInSubnetError):
+        dhcp6_parser.add_pool_to_subnet(
+            id=40123, start="2001:db8:FFFF:FFFF::100", end="2001:db8::200"
+        )
+
+
+def test_kea_dhcp6_parser_subnet_remove_pool(dhcp6_parser: Dhcp6Parser):
+    dhcp6_parser.remove_subnet_pool(id=40123, pool="2001:db8::100-2001:db8::200")
+    subnet = dhcp6_parser.get_subnet(id=40123)
+    assert len(subnet.pools) == 0
+
+
+def test_kea_dhcp6_parser_subnet_get_subnet_from_default_gateway(
+    dhcp6_parser: Dhcp6Parser,
+):
+    subnet = dhcp6_parser.get_subnet_by_default_gateway(ip_address="2001:db8::1")
+    assert subnet
+    assert subnet.id == 40123
+
+
+def test_kea_dhcp6_parser_add_subnet_to_shared_network(dhcp6_parser: Dhcp6Parser):
+    shared_network = dhcp6_parser.add_subnet_to_shared_network(
+        id=40123, name="pykeadhcp-dhcp6-parser"
+    )
+
+    assert len(shared_network.subnet) > 0
+
+
+def test_kea_dhcp6_parser_remove_subnet_from_shared_network(dhcp6_parser: Dhcp6Parser):
+    dhcp6_parser.remove_subnet_from_shared_network(
+        id=40123, name="pykeadhcp-dhcp6-parser"
+    )
+    shared_network = dhcp6_parser.get_shared_network(name="pykeadhcp-dhcp6-parser")
+    assert len(shared_network.subnet6) == 0
+
+
+def test_kea_dhcp6_parser_remove_shared_network(dhcp6_parser: Dhcp6Parser):
+    dhcp6_parser.remove_shared_network(name="pykeadhcp-dhcp6-parser")
+    shared_network = dhcp6_parser.get_shared_network(name="pykeadhcp-dhcp6-parser")
+    assert shared_network == None

--- a/tests/configs/ctrlagent_api_config.json
+++ b/tests/configs/ctrlagent_api_config.json
@@ -1,5 +1,7 @@
 {
     "Control-agent": {
+        "cert-file": "/etc/kea/cert.pem",
+        "cert-required": false,
         "control-sockets": {
             "d2": {
                 "socket-name": "/tmp/kea-ddns-ctrl-socket",
@@ -17,12 +19,14 @@
         "hooks-libraries": [],
         "http-host": "0.0.0.0",
         "http-port": 8080,
+        "key-file": "/etc/kea/key.pem",
         "loggers": [
             {
                 "debuglevel": 0,
                 "name": "kea-ctrl-agent",
                 "severity": "INFO"
             }
-        ]
+        ],
+        "trust-anchor": "my-ca"
     }
 }

--- a/tests/configs/dhcp6_api_config.json
+++ b/tests/configs/dhcp6_api_config.json
@@ -1,0 +1,156 @@
+{
+    "Dhcp6": {
+        "calculate-tee-times": true,
+        "control-socket": {
+            "socket-name": "/tmp/kea6-ctrl-socket",
+            "socket-type": "unix"
+        },
+        "ddns-generated-prefix": "myhost",
+        "ddns-override-client-update": false,
+        "ddns-override-no-update": false,
+        "ddns-qualifying-suffix": "",
+        "ddns-replace-client-name": "never",
+        "ddns-send-updates": true,
+        "decline-probation-period": 86400,
+        "dhcp-ddns": {
+            "enable-updates": false,
+            "max-queue-size": 1024,
+            "ncr-format": "JSON",
+            "ncr-protocol": "UDP",
+            "sender-ip": "0.0.0.0",
+            "sender-port": 0,
+            "server-ip": "127.0.0.1",
+            "server-port": 53001
+        },
+        "dhcp-queue-control": {
+            "capacity": 64,
+            "enable-queue": false,
+            "queue-type": "kea-ring6"
+        },
+        "dhcp4o6-port": 0,
+        "expired-leases-processing": {
+            "flush-reclaimed-timer-wait-time": 25,
+            "hold-reclaimed-time": 3600,
+            "max-reclaim-leases": 100,
+            "max-reclaim-time": 250,
+            "reclaim-timer-wait-time": 10,
+            "unwarned-reclaim-cycles": 5
+        },
+        "hooks-libraries": [
+            {
+                "library": "/usr/local/lib/kea/hooks/libdhcp_lease_cmds.so",
+                "parameters": {}
+            },
+            {
+                "library": "/usr/local/lib/kea/hooks/libdhcp_subnet_cmds.so"
+            },
+            {
+                "library": "/usr/local/lib/kea/hooks/libdhcp_host_cmds.so"
+            }
+        ],
+        "host-reservation-identifiers": [
+            "hw-address",
+            "duid"
+        ],
+        "hostname-char-replacement": "",
+        "hostname-char-set": "[^A-Za-z0-9.-]",
+        "interfaces-config": {
+            "interfaces": [],
+            "re-detect": true
+        },
+        "lease-database": {
+            "persist": true,
+            "type": "memfile"
+        },
+        "loggers": [
+            {
+                "debuglevel": 99,
+                "name": "kea-dhcp6",
+                "output_options": [
+                    {
+                        "flush": true,
+                        "maxsize": 10000000,
+                        "maxver": 2,
+                        "output": "/usr/local/var/log/kea-dhcp6.log"
+                    }
+                ],
+                "severity": "INFO"
+            }
+        ],
+        "mac-sources": [
+            "any"
+        ],
+        "multi-threading": {
+            "enable-multi-threading": false,
+            "packet-queue-size": 64,
+            "thread-pool-size": 0
+        },
+        "option-data": [],
+        "option-def": [],
+        "preferred-lifetime": 3600,
+        "rebind-timer": 2000,
+        "relay-supplied-options": [
+            "65"
+        ],
+        "renew-timer": 1000,
+        "reservation-mode": "all",
+        "sanity-checks": {
+            "lease-checks": "warn"
+        },
+        "server-id": {
+            "enterprise-id": 0,
+            "htype": 0,
+            "identifier": "",
+            "persist": true,
+            "time": 0,
+            "type": "LLT"
+        },
+        "server-tag": "",
+        "shared-networks": [],
+        "statistic-default-sample-age": 0,
+        "statistic-default-sample-count": 20,
+        "store-extended-info": false,
+        "subnet6": [
+            {
+                "calculate-tee-times": true,
+                "id": 1,
+                "option-data": [],
+                "pd-pools": [
+                    {
+                        "delegated-len": 56,
+                        "option-data": [],
+                        "prefix": "2001:db8::",
+                        "prefix-len": 48
+                    }
+                ],
+                "pools": [
+                    {
+                        "option-data": [],
+                        "pool": "2001:db8:1000:6464::100-2001:db8:1000:6464::FFFF"
+                    }
+                ],
+                "preferred-lifetime": 432000,
+                "rapid-commit": false,
+                "rebind-timer": 302400,
+                "relay": {
+                    "ip-addresses": [
+                        "2001:db8:1000:6464::1"
+                    ]
+                },
+                "renew-timer": 115200,
+                "reservations": [],
+                "store-extended-info": false,
+                "subnet": "2001:db8:1000:6464::/64",
+                "t1-percent": 0.5,
+                "t2-percent": 0.8,
+                "user-context": {
+                    "comment": "some-subnet-comment"
+                },
+                "valid-lifetime": 604800
+            }
+        ],
+        "t1-percent": 0.5,
+        "t2-percent": 0.8,
+        "valid-lifetime": 4000
+    }
+}

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -26,14 +26,39 @@ def pytest_addoption(parser):
         help="Port for Kea Server API",
         default=8000,
     )
+    parser.addoption(
+        "--disable-ssl-verify",
+        action="store_true",
+        dest="disable_ssl_verify",
+        default=False,
+        help="Disable SSL Verification when calling Kea class",
+    )
+    parser.addoption(
+        "--ssl-ca-bundle",
+        action="store",
+        dest="ssl_ca_bundle",
+        type=str,
+        help="CA Bundle if required to pass into requests module",
+        default=None,
+    )
 
 
 @pytest.fixture(scope="module")
 def kea_server(request: FixtureRequest):
     host = request.config.getoption("host")
     port = request.config.getoption("port", default=8000)
+    disable_ssl_verify = request.config.getoption("disable_ssl_verify", default=False)
+    ssl_ca_bundle = request.config.getoption("ssl_ca_bundle", default=None)
 
-    return Kea(host=host, port=port)
+    return Kea(
+        host=host,
+        port=port,
+        verify=False
+        if disable_ssl_verify
+        else True
+        if not ssl_ca_bundle
+        else ssl_ca_bundle,
+    )
 
 
 def read_local_config(filename: str):

--- a/tests/test_infrastructure/Dockerfile
+++ b/tests/test_infrastructure/Dockerfile
@@ -77,6 +77,9 @@ RUN [ "${KEA_PREMIUM}" != "premium" ] || ( \
         isc-kea-premium-forensic-log=${KEA_VERSION} \
         isc-kea-premium-host-cache=${KEA_VERSION} \
         isc-kea-premium-radius=${KEA_VERSION} \
+        isc-kea-premium-flex-id=${KEA_VERSION} \
+        isc-kea-premium-subnet-cmds=${KEA_VERSION} \
+        isc-kea-premium-lease-cmds=${KEA_VERSION} \
         && apt-get clean \
         && rm -rf /var/lib/apt/lists/* \
         && mkdir -p /var/run/kea/ \


### PR DESCRIPTION
- Addresses issue #12 
- Addresses issue #16 
- General model cleanup for reused variables
- pytest for Dhcp6 related calls
- Updated CA test api config to include TLS configuration options
- Added extra installations in Dockerfile for premium hooks

Local test:
```
(.venv) brandon@dev-1:~/pykeadhcp$ pytest -s tests -k "not shutdown and not set and not write and not delta" --host https://localhost --disable-ssl-verify
============================================================================================================= test session starts ==============================================================================================================
platform linux -- Python 3.10.6, pytest-7.2.2, pluggy-1.0.0
rootdir: /home/brandon/pykeadhcp
collected 174 items / 13 deselected / 161 selected                                                                                                                                                                                             

tests/ci/models/test_ci_kea_ctrlagent_config_model.py .....
tests/ci/models/test_ci_kea_dhcp4_config_model.py .........
tests/ci/parsers/test_ci_kea_dhcp4_parser.py ...........................
tests/ci/parsers/test_ci_kea_dhcp6_parser.py ..............................
tests/ctrlagent/test_kea_ctrlagent.py ......
tests/ctrlagent/test_kea_ctrlagent_parser.py ..
tests/dhcp4/test_kea_dhcp4.py .........
tests/dhcp4/test_kea_dhcp4_lease4.py ...........
tests/dhcp4/test_kea_dhcp4_network4.py .......
tests/dhcp4/test_kea_dhcp4_parser.py ..
tests/dhcp4/test_kea_dhcp4_statistics.py ...
tests/dhcp4/test_kea_dhcp4_subnet4.py .........
tests/dhcp6/test_kea_dhcp6.py .........
tests/dhcp6/test_kea_dhcp6_lease6.py ...........
tests/dhcp6/test_kea_dhcp6_network6.py ........
tests/dhcp6/test_kea_dhcp6_parser.py ..
tests/dhcp6/test_kea_dhcp6_statistics.py ...
tests/dhcp6/test_kea_dhcp6_subnet6.py ........

=============================================================================================================== warnings summary ===============================================================================================================
tests/ctrlagent/test_kea_ctrlagent.py: 6 warnings
tests/ctrlagent/test_kea_ctrlagent_parser.py: 2 warnings
tests/dhcp4/test_kea_dhcp4.py: 9 warnings
tests/dhcp4/test_kea_dhcp4_lease4.py: 11 warnings
tests/dhcp4/test_kea_dhcp4_network4.py: 7 warnings
tests/dhcp4/test_kea_dhcp4_parser.py: 2 warnings
tests/dhcp4/test_kea_dhcp4_statistics.py: 3 warnings
tests/dhcp4/test_kea_dhcp4_subnet4.py: 9 warnings
tests/dhcp6/test_kea_dhcp6.py: 9 warnings
tests/dhcp6/test_kea_dhcp6_lease6.py: 11 warnings
tests/dhcp6/test_kea_dhcp6_network6.py: 8 warnings
tests/dhcp6/test_kea_dhcp6_parser.py: 2 warnings
tests/dhcp6/test_kea_dhcp6_statistics.py: 3 warnings
tests/dhcp6/test_kea_dhcp6_subnet6.py: 8 warnings
  /home/brandon/pykeadhcp/.venv/lib/python3.10/site-packages/urllib3/connectionpool.py:1056: InsecureRequestWarning: Unverified HTTPS request is being made to host 'localhost'. Adding certificate verification is strongly advised. See: https://urllib3.readthedocs.io/en/1.26.x/advanced-usage.html#ssl-warnings
    warnings.warn(

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
=============================================================================================== 161 passed, 13 deselected, 90 warnings in 29.99s ===============================================================================================
```

v0.4.0 will be released after testing v0.4.0a0