### PR TITLE
Fixed lease4_get_all and lease6_get_all commands, added tests

### DIFF
--- a/pykeadhcp/daemons/dhcp4.py
+++ b/pykeadhcp/daemons/dhcp4.py
@@ -231,12 +231,19 @@ class Dhcp4:
         Kea API Reference:
             https://kea.readthedocs.io/en/kea-2.2.0/api.html#lease4-get-all
         """
-        data = self.api.send_command_with_arguments(
-            command="lease4-get-all",
-            service=self.service,
-            arguments={"subnets": subnets},
-            required_hook="lease_cmds",
-        )
+        if subnets:
+            data = self.api.send_command_with_arguments(
+                command="lease4-get-all",
+                service=self.service,
+                arguments={"subnets": subnets},
+                required_hook="lease_cmds",
+            )
+        else:
+            data = self.api.send_command(
+                command="lease4-get-all",
+                service=self.service,
+                required_hook="lease_cmds",
+            )
 
         if data.result == 3:
             raise KeaLeaseNotFoundException(data.text)

--- a/pykeadhcp/daemons/dhcp6.py
+++ b/pykeadhcp/daemons/dhcp6.py
@@ -210,12 +210,19 @@ class Dhcp6:
         Kea API Reference:
             https://kea.readthedocs.io/en/kea-2.2.0/api.html#lease6-get-all
         """
-        data = self.api.send_command_with_arguments(
-            command="lease6-get-all",
-            service=self.service,
-            arguments={"subnets": subnets},
-            required_hook="lease_cmds",
-        )
+        if subnets:
+            data = self.api.send_command_with_arguments(
+                command="lease6-get-all",
+                service=self.service,
+                arguments={"subnets": subnets},
+                required_hook="lease_cmds",
+            )
+        else:
+            data = self.api.send_command(
+                command="lease6-get-all",
+                service=self.service,
+                required_hook="lease_cmds",
+            )
 
         if data.result == 3:
             raise KeaLeaseNotFoundException(data.text)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "pykeadhcp"
-version = "0.5.0"
+version = "0.5.1"
 description = "Wrapper around requests module to query ISC Kea DHCP API Daemons (ctrlagent, dhcp4, dhcp6, ddns)"
 authors = ["Brandon Spendlove <brandon-spendlove@hotmail.co.uk>"]
 license = "Apache 2.0"

--- a/tests/dhcp4/test_kea_dhcp4_lease4.py
+++ b/tests/dhcp4/test_kea_dhcp4_lease4.py
@@ -24,6 +24,11 @@ def test_kea_dhcp4_lease4_get_non_exsistent(kea_server: Kea):
         kea_server.dhcp4.lease4_get(ip_address="192.0.2.32")
 
 
+def test_kea_dhcp4_lease4_get_all_none(kea_server: Kea):
+    with pytest.raises(KeaLeaseNotFoundException):
+        kea_server.dhcp4.lease4_get_all()
+
+
 def test_kea_dhcp4_lease4_add(kea_server: Kea):
     # Add Temporary Subnet
     data = Subnet4(id=40123, subnet="192.0.2.32/31")
@@ -50,6 +55,11 @@ def test_kea_dhcp4_lease4_get(kea_server: Kea):
 
 
 def test_kea_dhcp4_lease4_get_all(kea_server: Kea):
+    response = kea_server.dhcp4.lease4_get_all()
+    assert len(response) > 0
+
+
+def test_kea_dhcp4_lease4_get_all_subnets(kea_server: Kea):
     response = kea_server.dhcp4.lease4_get_all(subnets=[40123])
     assert len(response) > 0
 

--- a/tests/dhcp6/test_kea_dhcp6_lease6.py
+++ b/tests/dhcp6/test_kea_dhcp6_lease6.py
@@ -24,6 +24,11 @@ def test_kea_dhcp6_lease6_get_non_exsistent(kea_server: Kea):
         kea_server.dhcp6.lease6_get(ip_address="2001:db8::32")
 
 
+def test_kea_dhcp4_lease6_get_all_none(kea_server: Kea):
+    with pytest.raises(KeaLeaseNotFoundException):
+        kea_server.dhcp6.lease6_get_all()
+
+
 def test_kea_dhcp6_lease6_add(kea_server: Kea):
     # Add Temporary Subnet
     data = Subnet6(id=40123, subnet="2001:db8::/64")
@@ -46,7 +51,12 @@ def test_kea_dhcp6_lease6_get(kea_server: Kea):
     assert response.iaid == 1234
 
 
-def test_kea_dhcp6_lease6_get_all(kea_server: Kea):
+def test_kea_dhcp4_lease6_get_all(kea_server: Kea):
+    response = kea_server.dhcp6.lease6_get_all()
+    assert len(response) > 0
+
+
+def test_kea_dhcp6_lease6_get_all_subnets(kea_server: Kea):
     response = kea_server.dhcp6.lease6_get_all(subnets=[40123])
     assert len(response) > 0
 


### PR DESCRIPTION
- Addresses issue #23 

Local test:

```
(.venv) brandon@dev-1:~/pykeadhcp$ pytest -s tests -k "not shutdown and not set and not write and not delta" --host https://localhost --disable-ssl-verify
=============================================================================================== test session starts ================================================================================================
platform linux -- Python 3.10.6, pytest-7.2.2, pluggy-1.0.0
rootdir: /home/brandon/pykeadhcp
collected 183 items / 13 deselected / 170 selected                                                                                                                                                                 

tests/ci/models/test_ci_kea_ctrlagent_config_model.py .....
tests/ci/models/test_ci_kea_dhcp4_config_model.py ..........
tests/ci/models/test_ci_kea_dhcp6_config_model.py ....
tests/ci/parsers/test_ci_kea_dhcp4_parser.py ...........................
tests/ci/parsers/test_ci_kea_dhcp6_parser.py ..............................
tests/ctrlagent/test_kea_ctrlagent.py ......
tests/ctrlagent/test_kea_ctrlagent_parser.py ..
tests/dhcp4/test_kea_dhcp4.py .........
tests/dhcp4/test_kea_dhcp4_lease4.py .............
tests/dhcp4/test_kea_dhcp4_network4.py .......
tests/dhcp4/test_kea_dhcp4_parser.py ..
tests/dhcp4/test_kea_dhcp4_statistics.py ...
tests/dhcp4/test_kea_dhcp4_subnet4.py .........
tests/dhcp6/test_kea_dhcp6.py .........
tests/dhcp6/test_kea_dhcp6_lease6.py .............
tests/dhcp6/test_kea_dhcp6_network6.py ........
tests/dhcp6/test_kea_dhcp6_parser.py ..
tests/dhcp6/test_kea_dhcp6_statistics.py ...
tests/dhcp6/test_kea_dhcp6_subnet6.py ........

================================================================================= 170 passed, 13 deselected, 94 warnings in 30.96s =================================================================================
```